### PR TITLE
fix: sortable linkable

### DIFF
--- a/app/Filament/Resources/SocialLinkResource.php
+++ b/app/Filament/Resources/SocialLinkResource.php
@@ -112,8 +112,7 @@ class SocialLinkResource extends Resource
         return $table
             ->columns([
                 TextColumn::make('linkable.name')
-                    ->searchable()
-                    ->sortable(),
+                    ->searchable(),
 
                 TextColumn::make('url'),
             ])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed sorting capability from the column displaying linked names in the social links table. The column remains searchable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->