### PR TITLE
feat: add office location data processing with geocoding and  cleanup

### DIFF
--- a/app/Actions/GeocodeLocationAction.php
+++ b/app/Actions/GeocodeLocationAction.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Actions;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class GeocodeLocationAction
+{
+    protected string $baseUrl = 'https://nominatim.openstreetmap.org/search';
+
+    public function __construct(
+        protected int $cacheTtl = 2592000 // 30 days in seconds
+    ) {}
+
+    public function execute(string $location): ?array
+    {
+        $cacheKey = 'geocode_' . md5($location);
+
+        return Cache::remember($cacheKey, $this->cacheTtl, function () use ($location): ?array {
+            try {
+                sleep(1); // 1 second delay for rate limit
+
+                $response = Http::withHeaders([
+                    'User-Agent' => config('app.name', 'Laravel') . ' Application',
+                ])->get($this->baseUrl, [
+                    'q' => $location,
+                    'format' => 'json',
+                    'limit' => 1,
+                ]);
+
+                $data = $response->json()[0] ?? null;
+
+                if ($response->successful() && $data) {
+                    return [
+                        'lat' => (float) $data['lat'],
+                        'lng' => (float) $data['lon'],
+                        'display_name' => $data['display_name'] ?? null,
+                        'type' => $data['type'] ?? null,
+                        'importance' => $data['importance'] ?? null,
+                    ];
+                }
+
+                Log::warning('Geocoding failed', [
+                    'location' => $location,
+                    'status' => $response->status(),
+                    'response' => $response->json(),
+                ]);
+            } catch (Throwable $e) {
+                Log::error('Geocoding error', [
+                    'location' => $location,
+                    'exception' => $e->getMessage(),
+                ]);
+            }
+
+            return null;
+        });
+    }
+}

--- a/app/Console/Commands/OutputOfficeLocationDataCommand.php
+++ b/app/Console/Commands/OutputOfficeLocationDataCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\OfficeLocation;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class OutputOfficeLocationDataCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'office-locations:output-data';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Output office location data to be batch processed';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $this->info('Outputting office location data...');
+
+        $counter = 1;
+        OfficeLocation::query()
+            ->select(['id', 'name'])
+            ->chunk(500, function ($locations) use (&$counter): void {
+                $data = $locations->toArray();
+
+                $fileName = "exports/office_locations_{$counter}.json";
+
+                Storage::disk('local')->put($fileName, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+                $counter++;
+            });
+
+        $this->info('Office location data output complete.');
+
+        $this->newLine();
+
+    }
+}

--- a/app/Console/Commands/UpdateCleanedOfficeLocationCommand.php
+++ b/app/Console/Commands/UpdateCleanedOfficeLocationCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+class UpdateCleanedOfficeLocationCommand extends Command
+{
+    protected $signature = 'office-locations:update-cleaned';
+
+    protected $description = 'Updated cleaned office locations names after clean them with AI';
+
+    public function handle(): ?int
+    {
+        $files = Storage::disk('local')->files('exports');
+        natsort($files); // sort files naturally because the result is: file1, file10, file11, ... file2
+
+        if ($files === []) {
+            $this->warn('No JSON files found in: exports');
+
+            return Command::SUCCESS;
+        }
+
+        $files = array_values($files); // reset ordered ids
+
+        foreach ($files as $file) {
+            $this->info("Processing: $file");
+
+            $data = json_decode((string) Storage::disk('local')->get($file), true);
+
+            $progressBar = $this->output->createProgressBar(count($data));
+
+            foreach ($data as $row) {
+
+                // skip rows without id
+                if (! isset($row['id'])) {
+                    continue;
+                }
+
+                $id = $row['id'];
+
+                // Remove the key from update data
+                $updatedData = array_filter($row, fn ($col): bool => $col !== 'id', ARRAY_FILTER_USE_KEY);
+
+                DB::table('office_locations')->where('id', $id)->update($updatedData);
+
+                $progressBar->advance();
+            }
+
+            $progressBar->finish();
+
+            $this->info('Update complete.');
+
+            return Command::SUCCESS;
+        }
+
+        return null;
+    }
+}

--- a/app/Filament/Resources/OfficeLocationResource.php
+++ b/app/Filament/Resources/OfficeLocationResource.php
@@ -30,7 +30,7 @@ class OfficeLocationResource extends Resource
     {
         return $form
             ->schema([
-                TextInput::make('name')->required(),
+                TextInput::make('name')->required()->unique('office_locations', 'name'),
                 TextInput::make('lat'),
                 TextInput::make('lng'),
             ]);

--- a/app/Models/OfficeLocation.php
+++ b/app/Models/OfficeLocation.php
@@ -17,6 +17,7 @@ class OfficeLocation extends Model
      */
     protected $fillable = [
         'name',
+        'old_name',
         'lat',
         'lng',
     ];
@@ -36,5 +37,25 @@ class OfficeLocation extends Model
     public function companies(): BelongsToMany
     {
         return $this->belongsToMany(Company::class);
+    }
+
+    /**
+     * Get the city part from the location.
+     */
+    public function getCity(): ?string
+    {
+        $parts = explode(',', $this->name);
+
+        return trim((string) ($parts[0] ?? null));
+    }
+
+    /**
+     * Get the country part from the location.
+     */
+    public function getCountry(): ?string
+    {
+        $parts = explode(',', $this->name);
+
+        return trim((string) ($parts[1] ?? null));
     }
 }

--- a/database/migrations/2025_06_08_000000_update_office_locations_table.php
+++ b/database/migrations/2025_06_08_000000_update_office_locations_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateOfficeLocationsTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('office_locations', function (Blueprint $table): void {
+            if (! Schema::hasColumn('office_locations', 'old_name')) {
+                $table->string('old_name')->nullable()->after('name');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('office_locations', function (Blueprint $table): void {
+            $table->dropColumn('old_name');
+        });
+    }
+}

--- a/database/migrations/2025_06_18_180602_stop_unique_containts_on_office_locations_table.php
+++ b/database/migrations/2025_06_18_180602_stop_unique_containts_on_office_locations_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('office_locations', function (Blueprint $table): void {
+            $table->dropUnique(['name']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('office_locations', function (Blueprint $table): void {
+            $table->string('name')->unique()->change();
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,3 +41,14 @@ Route::get('similar-sites', [HomeController::class, 'similarSites'])->name('simi
 
 // Webhooks
 Route::get('webhooks/mailchimp', MailchimpRedirectionController::class)->name('mailchimp.webhook');
+
+// output to json as following:
+
+// stop unique constraints in office_location table temporarily (done)
+// remove all non-needing code in this direction
+
+// output all office location data to json file (done)
+// process the json file and clean location names in AI service (progress
+// import the json file to office_location using separate command
+// run command "OfficeLocationsMergerAllCommand" to merge similar commands
+// todo remove this later


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added geocoding functionality for office locations using the OpenStreetMap Nominatim API.
  - Introduced console commands to export office location data to JSON files and update records from cleaned data.
  - Added methods to extract city and country from office location names.

- **Enhancements**
  - Made the office location name field unique in the resource form.
  - Extended the office locations model to support an additional attribute for old names.

- **Database**
  - Added a new column for storing old office location names.
  - Provided migrations to add/remove the unique constraint on office location names.

- **Documentation**
  - Added detailed comments outlining the office location data cleaning workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->