### PR TITLE
feat: add old_name column to office locations table display

### DIFF
--- a/app/Filament/Resources/OfficeLocationResource.php
+++ b/app/Filament/Resources/OfficeLocationResource.php
@@ -42,6 +42,7 @@ class OfficeLocationResource extends Resource
             ->recordUrl(null) // make record non-clickable
             ->columns([
                 TextColumn::make('name')->sortable()->searchable(),
+                TextColumn::make('old_name')->sortable()->searchable(),
                 TextColumn::make('companies.name')->badge()->color('info')->searchable(),
                 TextColumn::make('lat'),
                 TextColumn::make('lng'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new column to the office locations table view to display the 'old name' attribute, which is now sortable and searchable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->