### PR TITLE
feat: add command to sync company tags with their alternative companies

### DIFF
--- a/app/Console/Commands/SyncCompanyTagsToAlternativesCommand.php
+++ b/app/Console/Commands/SyncCompanyTagsToAlternativesCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Company;
+use Illuminate\Console\Command;
+
+class SyncCompanyTagsToAlternativesCommand extends Command
+{
+    protected $signature = 'tags:sync-company-to-alternatives';
+
+    protected $description = "Sync each company's tags with its related alternative companies";
+
+    public function handle(): int
+    {
+        $companies = Company::query()
+            ->with(['tagsRelation', 'alternatives:id,name'])
+            ->select('id', 'name')
+            ->get();
+
+        $this->output->progressStart(count($companies));
+
+        foreach ($companies as $company) {
+            $tagIds = $company->tagsRelation()->pluck('tag_id')->toArray();
+
+            if (empty($tagIds)) {
+                continue;
+            }
+
+            foreach ($company->alternatives as $alternative) {
+                $alternative->tagsRelation()->syncWithoutDetaching($tagIds);
+            }
+
+            $this->output->progressAdvance();
+        }
+
+        $this->output->progressFinish();
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Feature/Console/Commands/SyncCompanyTagsToAlternativesCommandTest.php
+++ b/tests/Feature/Console/Commands/SyncCompanyTagsToAlternativesCommandTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Console\Commands\SyncCompanyTagsToAlternativesCommand;
+use App\Models\Alternative;
+use App\Models\Company;
+use App\Models\Tag;
+
+test('it syncs company tags to related alternatives', function (): void {
+    $tag1 = Tag::factory()->create(['name' => 'Tag 1 for company']);
+    $tag2 = Tag::factory()->create(['name' => 'Tag 2 for company']);
+    $tag3 = Tag::factory()->create(['name' => 'Tag 3 for alternative 1']);
+
+    $company = Company::factory()->create(['name' => 'Test Company']);
+    $company->tagsRelation()->attach([$tag1->id, $tag2->id]);
+
+    $alternative1 = Alternative::factory()->create(['name' => 'Alternative 1']);
+    $alternative2 = Alternative::factory()->create(['name' => 'Alternative 2']);
+    $alternative2->tagsRelation()->attach([$tag3->id]);
+
+    $company->alternatives()->attach([$alternative1->id, $alternative2->id]);
+
+    expect($alternative1->tagsRelation()->count())->toBe(0);
+    expect($alternative2->tagsRelation()->count())->toBe(1);
+
+    $this->artisan(SyncCompanyTagsToAlternativesCommand::class)->assertExitCode(0);
+
+    $alternative1->refresh();
+    $alternative2->refresh();
+
+    expect($alternative1->tagsRelation()->count())->toBe(2);
+    expect($alternative2->tagsRelation()->count())->toBe(3);
+    expect($company->tagsRelation()->count())->toBe(2);
+
+    expect($alternative1->hasTag($tag1))->toBeTrue();
+    expect($alternative1->hasTag($tag2))->toBeTrue();
+    expect($alternative2->hasTag($tag1))->toBeTrue();
+    expect($alternative2->hasTag($tag2))->toBeTrue();
+    expect($alternative2->hasTag($tag3))->toBeTrue();
+    expect($alternative1->hasTag($tag3))->toBeFalse();
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a console command to synchronize company tags with their alternative companies, ensuring alternatives inherit tags without removing their existing ones.

- **Tests**
  - Added tests to verify correct synchronization of tags between companies and their alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->