### PR TITLE
fix:  bug when no alternative description for SEO

### DIFF
--- a/app/Actions/SeoSetAlternativePageAction.php
+++ b/app/Actions/SeoSetAlternativePageAction.php
@@ -14,9 +14,11 @@ class SeoSetAlternativePageAction
 
     public function execute(Alternative $alternative): void
     {
+        $formatDescription = $this->formatAlternativeDescription($alternative);
+
         $this->seoSetPageAction->execute(
             $alternative->name,
-            $alternative->description,
+            $formatDescription,
             $alternative->image_path,
             'product'
         );
@@ -24,7 +26,7 @@ class SeoSetAlternativePageAction
         // Add structured data for product
         JsonLdMulti::setType('Product');
         JsonLdMulti::addValue('name', $alternative->name);
-        JsonLdMulti::addValue('description', $alternative->description);
+        JsonLdMulti::addValue('description', $formatDescription);
         JsonLdMulti::addValue('url', $alternative->url);
 
         // Add tags as keywords
@@ -32,5 +34,14 @@ class SeoSetAlternativePageAction
             $keywords = $alternative->tagsRelation->pluck('name')->implode(', ');
             SEOMeta::addKeyword($keywords);
         }
+    }
+
+    private function formatAlternativeDescription(Alternative $alternative): string
+    {
+        if ($alternative->description) {
+            return $alternative->description;
+        }
+
+        return "{$alternative->name} ({$alternative->slug})";
     }
 }

--- a/database/factories/AlternativeFactory.php
+++ b/database/factories/AlternativeFactory.php
@@ -3,6 +3,8 @@
 namespace Database\Factories;
 
 use App\Models\Alternative;
+use Carbon\Carbon;
+use DateTime;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -24,10 +26,15 @@ class AlternativeFactory extends Factory
     {
         return [
             'name' => fake()->name(),
-            'description' => fake()->text(),
-            'approved_at' => fake()->dateTime(),
             'notes' => fake()->text(),
             'url' => fake()->url(),
         ];
+    }
+
+    public function approved(DateTime|Carbon|null $datTime = null): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'approved_at' => $datTime ?? Carbon::now(),
+        ]);
     }
 }

--- a/tests/Feature/Http/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerTest.php
@@ -24,4 +24,4 @@ test('show alternative displays view', function (): void {
     $response->assertViewHas('alternative.resources');
     $response->assertViewHas('alternative.tagsRelation');
     $response->assertViewHas('alternative.companies');
-})->only();
+});

--- a/tests/Feature/Http/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Models\Alternative;
+
+use function Pest\Laravel\get;
+
+test('show alternative displays view', function (): void {
+    $this->withoutExceptionHandling();
+    $alternative = Alternative::factory()
+        ->approved()
+        ->create();
+
+    $response = get(route('alternatives.show', $alternative));
+
+    $response->assertOk();
+    $response->assertViewIs('alternatives.show');
+    $response->assertViewHas('alternative');
+
+    $response->assertSee($alternative->name);
+
+    // checks relationships
+    $response->assertViewHas('alternative.resources');
+    $response->assertViewHas('alternative.tagsRelation');
+    $response->assertViewHas('alternative.companies');
+})->only();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a feature test to verify that alternative pages display correctly, including related data and content.
* **Bug Fixes**
  * Improved fallback logic for alternative descriptions on SEO pages, ensuring a description is always shown when missing.
* **Tests**
  * Introduced targeted tests to validate the display and content of alternative detail pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->