### PR TITLE
feat: format referencing in new style

### DIFF
--- a/app/Actions/FormatResourcesWikipediaStyleAction.php
+++ b/app/Actions/FormatResourcesWikipediaStyleAction.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Actions;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class FormatResourcesWikipediaStyleAction
+{
+    /**
+     * Format a collection of resource URLs into a Wikipedia-style reference format.
+     *
+     * Example Output:
+     * [
+     *     'https://techaviv.com/page1' => 'techaviv.com [1]',
+     *     'https://techaviv.com/page2' => '[2]',
+     *     'https://techaviv.com/page3' => '[3]',
+     * ]
+     */
+    public function execute(Collection $resources): array
+    {
+        $counter = [];
+
+        return $resources->pluck('url')->mapWithKeys(function ($url) use (&$counter) {
+            $name = Str::ltrim(parse_url($url, PHP_URL_HOST), 'www.') ?: $url;
+
+            $count = ($counter[$name] ?? 0) + 1;
+            $counter[$name] = $count;
+
+            $label = $count === 1
+                ? "{$name} [{$count}]"
+                : "[{$count}]";
+
+            return [$url => $label];
+        })->toArray();
+    }
+}

--- a/app/Http/Controllers/CompanyController.php
+++ b/app/Http/Controllers/CompanyController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Actions\FormatResourcesAction;
+use App\Actions\FormatResourcesWikipediaStyleAction;
 use App\Actions\SeoSetCompanyPageAction;
 use App\Actions\SeoSetPageAction;
 use App\Http\Requests\NewCompanyRequest;
@@ -64,7 +64,7 @@ class CompanyController extends Controller
     public function show(
         Request $request,
         Company $company,
-        FormatResourcesAction $formatResourcesAction,
+        FormatResourcesWikipediaStyleAction $formatResourcesAction,
         SeoSetCompanyPageAction $seoSetCompanyPageAction
     ): View {
         abort_if(! $company->approved_at, 404);

--- a/app/Http/Controllers/InvestorController.php
+++ b/app/Http/Controllers/InvestorController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Actions\FormatResourcesAction;
+use App\Actions\FormatResourcesWikipediaStyleAction;
 use App\Actions\SeoSetInvestorPageAction;
 use App\Models\Investor;
 
@@ -24,7 +24,7 @@ class InvestorController extends Controller
 
     public function show(
         Investor $investor,
-        FormatResourcesAction $formatResourcesAction,
+        FormatResourcesWikipediaStyleAction $formatResourcesAction,
         SeoSetInvestorPageAction $seoSetInvestorPageAction
     ) {
         $seoSetInvestorPageAction->execute($investor);

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Actions\FormatResourcesAction;
+use App\Actions\FormatResourcesWikipediaStyleAction;
 use App\Actions\SeoSetPersonPageAction;
 use App\Models\Person;
 use Illuminate\Http\Request;
@@ -27,7 +27,7 @@ class PersonController extends Controller
     public function show(
         Request $request,
         Person $person,
-        FormatResourcesAction $formatResourcesAction,
+        FormatResourcesWikipediaStyleAction $formatResourcesAction,
         SeoSetPersonPageAction $seoSetPersonPageAction
     ) {
         abort_if(! $person->approved_at, 404);

--- a/resources/views/alternatives/show.blade.php
+++ b/resources/views/alternatives/show.blade.php
@@ -144,6 +144,70 @@
                             </div>
                         </div>
                     @endif
+
+                    <!-- Resources -->
+                    @if ($validResources->isNotEmpty())
+                        <div class="pt-8">
+                            <h2 class="mb-6 text-2xl font-bold text-gray-900">References</h2>
+
+                            <!-- Wikipedia-style reference list -->
+                            <div class="space-y-3">
+                                @php
+                                    $referenceNumber = 1;
+                                @endphp
+
+                                @foreach ($resources as $url => $label)
+                                    @if ($url == '#')
+                                        @continue
+                                    @endif
+
+                                    <div class="flex items-start space-x-3 text-sm">
+                                        <!-- Reference number -->
+                                        <span class="min-w-[2rem] flex-shrink-0 font-mono font-medium text-blue-600">
+                                            [{{ $referenceNumber }}]
+                                        </span>
+
+                                        <!-- Reference content -->
+                                        <div class="flex-1">
+                                            <a
+                                                href="{{ $url }}"
+                                                target="_blank"
+                                                class="break-all text-blue-600 hover:text-blue-800 hover:underline"
+                                            >
+                                                {{ parse_url($url, PHP_URL_HOST) ? Str::ltrim(parse_url($url, PHP_URL_HOST), 'www.') : $url }}
+                                            </a>
+                                            <span class="ml-1 text-gray-500">- {{ $url }}</span>
+
+                                            <!-- External link icon -->
+                                            <svg
+                                                class="ml-1 inline h-3 w-3 text-gray-400"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                viewBox="0 0 24 24"
+                                            >
+                                                <path
+                                                    stroke-linecap="round"
+                                                    stroke-linejoin="round"
+                                                    stroke-width="2"
+                                                    d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                                                ></path>
+                                            </svg>
+                                        </div>
+                                    </div>
+                                    @php
+                                        $referenceNumber++;
+                                    @endphp
+                                @endforeach
+                            </div>
+
+                            <!-- Optional: Add a note about references -->
+                            <div class="mt-6 border-t border-gray-200 pt-4">
+                                <p class="text-xs italic text-gray-500">
+                                    External links are provided for reference and verification purposes.
+                                </p>
+                            </div>
+                        </div>
+                    @endif
                 </div>
             </div>
         </div>

--- a/resources/views/companies/show.blade.php
+++ b/resources/views/companies/show.blade.php
@@ -299,29 +299,58 @@
                     @if ($company->resources->count() > 0)
                         <div class="pt-8">
                             <h2 class="mb-6 text-2xl font-bold text-gray-900">References</h2>
-                            <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+
+                            <!-- Wikipedia-style reference list -->
+                            <div class="space-y-3">
+                                @php
+                                    $referenceNumber = 1;
+                                @endphp
+
                                 @foreach ($resources as $url => $label)
-                                    <a
-                                        href="{{ $url }}"
-                                        target="_blank"
-                                        class="flex items-center rounded-lg border border-gray-200 p-4 transition-colors hover:bg-gray-50"
-                                    >
-                                        <svg
-                                            class="mr-3 h-5 w-5 flex-shrink-0 text-gray-400"
-                                            fill="none"
-                                            stroke="currentColor"
-                                            viewBox="0 0 24 24"
-                                        >
-                                            <path
-                                                stroke-linecap="round"
-                                                stroke-linejoin="round"
-                                                stroke-width="2"
-                                                d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-                                            ></path>
-                                        </svg>
-                                        <span class="font-medium text-gray-700 hover:text-blue-600">{{ $label }}</span>
-                                    </a>
+                                    <div class="flex items-start space-x-3 text-sm">
+                                        <!-- Reference number -->
+                                        <span class="min-w-[2rem] flex-shrink-0 font-mono font-medium text-blue-600">
+                                            [{{ $referenceNumber }}]
+                                        </span>
+
+                                        <!-- Reference content -->
+                                        <div class="flex-1">
+                                            <a
+                                                href="{{ $url }}"
+                                                target="_blank"
+                                                class="break-all text-blue-600 hover:text-blue-800 hover:underline"
+                                            >
+                                                {{ parse_url($url, PHP_URL_HOST) ? Str::ltrim(parse_url($url, PHP_URL_HOST), 'www.') : $url }}
+                                            </a>
+                                            <span class="ml-1 text-gray-500">- {{ $url }}</span>
+
+                                            <!-- External link icon -->
+                                            <svg
+                                                class="ml-1 inline h-3 w-3 text-gray-400"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                viewBox="0 0 24 24"
+                                            >
+                                                <path
+                                                    stroke-linecap="round"
+                                                    stroke-linejoin="round"
+                                                    stroke-width="2"
+                                                    d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                                                ></path>
+                                            </svg>
+                                        </div>
+                                    </div>
+                                    @php
+                                        $referenceNumber++;
+                                    @endphp
                                 @endforeach
+                            </div>
+
+                            <!-- Optional: Add a note about references -->
+                            <div class="mt-6 border-t border-gray-200 pt-4">
+                                <p class="text-xs italic text-gray-500">
+                                    External links are provided for reference and verification purposes.
+                                </p>
                             </div>
                         </div>
                     @endif

--- a/resources/views/investors/show.blade.php
+++ b/resources/views/investors/show.blade.php
@@ -134,29 +134,58 @@
                 @if ($investor->resources->count() > 0)
                     <div class="p-6 pt-8">
                         <h2 class="mb-6 text-2xl font-bold text-gray-900">References</h2>
-                        <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+
+                        <!-- Wikipedia-style reference list -->
+                        <div class="space-y-3">
+                            @php
+                                $referenceNumber = 1;
+                            @endphp
+
                             @foreach ($resources as $url => $label)
-                                <a
-                                    href="{{ $url }}"
-                                    target="_blank"
-                                    class="flex items-center rounded-lg border border-gray-200 p-4 transition-colors hover:bg-gray-50"
-                                >
-                                    <svg
-                                        class="mr-3 h-5 w-5 flex-shrink-0 text-gray-400"
-                                        fill="none"
-                                        stroke="currentColor"
-                                        viewBox="0 0 24 24"
-                                    >
-                                        <path
-                                            stroke-linecap="round"
-                                            stroke-linejoin="round"
-                                            stroke-width="2"
-                                            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-                                        ></path>
-                                    </svg>
-                                    <span class="font-medium text-gray-700 hover:text-blue-600">{{ $label }}</span>
-                                </a>
+                                <div class="flex items-start space-x-3 text-sm">
+                                    <!-- Reference number -->
+                                    <span class="min-w-[2rem] flex-shrink-0 font-mono font-medium text-blue-600">
+                                        [{{ $referenceNumber }}]
+                                    </span>
+
+                                    <!-- Reference content -->
+                                    <div class="flex-1">
+                                        <a
+                                            href="{{ $url }}"
+                                            target="_blank"
+                                            class="break-all text-blue-600 hover:text-blue-800 hover:underline"
+                                        >
+                                            {{ parse_url($url, PHP_URL_HOST) ? Str::ltrim(parse_url($url, PHP_URL_HOST), 'www.') : $url }}
+                                        </a>
+                                        <span class="ml-1 text-gray-500">- {{ $url }}</span>
+
+                                        <!-- External link icon -->
+                                        <svg
+                                            class="ml-1 inline h-3 w-3 text-gray-400"
+                                            fill="none"
+                                            stroke="currentColor"
+                                            viewBox="0 0 24 24"
+                                        >
+                                            <path
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                                            ></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                                @php
+                                    $referenceNumber++;
+                                @endphp
                             @endforeach
+                        </div>
+
+                        <!-- Optional: Add a note about references -->
+                        <div class="mt-6 border-t border-gray-200 pt-4">
+                            <p class="text-xs italic text-gray-500">
+                                External links are provided for reference and verification purposes.
+                            </p>
                         </div>
                     </div>
                 @endif

--- a/resources/views/people/show.blade.php
+++ b/resources/views/people/show.blade.php
@@ -87,36 +87,65 @@
                     $validResources = $person->resources->filter(fn ($resource) => $resource->url !== '#');
                 @endphp
 
-                @if ($validResources->isNotEmpty())
+                @if ($validResources->count() > 0)
                     <div class="p-6 pt-8">
                         <h2 class="mb-6 text-2xl font-bold text-gray-900">References</h2>
-                        <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+
+                        <!-- Wikipedia-style reference list -->
+                        <div class="space-y-3">
+                            @php
+                                $referenceNumber = 1;
+                            @endphp
+
                             @foreach ($resources as $url => $label)
                                 @if ($url == '#')
                                     @continue
                                 @endif
 
-                                <a
-                                    href="{{ $url }}"
-                                    target="_blank"
-                                    class="flex items-center rounded-lg border border-gray-200 p-4 transition-colors hover:bg-gray-50"
-                                >
-                                    <svg
-                                        class="mr-3 h-5 w-5 flex-shrink-0 text-gray-400"
-                                        fill="none"
-                                        stroke="currentColor"
-                                        viewBox="0 0 24 24"
-                                    >
-                                        <path
-                                            stroke-linecap="round"
-                                            stroke-linejoin="round"
-                                            stroke-width="2"
-                                            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-                                        ></path>
-                                    </svg>
-                                    <span class="font-medium text-gray-700 hover:text-blue-600">{{ $label }}</span>
-                                </a>
+                                <div class="flex items-start space-x-3 text-sm">
+                                    <!-- Reference number -->
+                                    <span class="min-w-[2rem] flex-shrink-0 font-mono font-medium text-blue-600">
+                                        [{{ $referenceNumber }}]
+                                    </span>
+
+                                    <!-- Reference content -->
+                                    <div class="flex-1">
+                                        <a
+                                            href="{{ $url }}"
+                                            target="_blank"
+                                            class="break-all text-blue-600 hover:text-blue-800 hover:underline"
+                                        >
+                                            {{ parse_url($url, PHP_URL_HOST) ? Str::ltrim(parse_url($url, PHP_URL_HOST), 'www.') : $url }}
+                                        </a>
+                                        <span class="ml-1 text-gray-500">- {{ $url }}</span>
+
+                                        <!-- External link icon -->
+                                        <svg
+                                            class="ml-1 inline h-3 w-3 text-gray-400"
+                                            fill="none"
+                                            stroke="currentColor"
+                                            viewBox="0 0 24 24"
+                                        >
+                                            <path
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                                            ></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                                @php
+                                    $referenceNumber++;
+                                @endphp
                             @endforeach
+                        </div>
+
+                        <!-- Optional: Add a note about references -->
+                        <div class="mt-6 border-t border-gray-200 pt-4">
+                            <p class="text-xs italic text-gray-500">
+                                External links are provided for reference and verification purposes.
+                            </p>
                         </div>
                     </div>
                 @endif

--- a/tests/Feature/Actions/FormatResourcesAction2Test.php
+++ b/tests/Feature/Actions/FormatResourcesAction2Test.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Actions\FormatResourcesWikipediaStyleAction;
+
+it('formats wikipedia style references for same domain', function (): void {
+    $resources = collect([
+        (object) ['url' => 'https://techaviv.com/page1'],
+        (object) ['url' => 'https://techaviv.com/page2'],
+        (object) ['url' => 'https://techaviv.com/page3'],
+    ]);
+
+    $result = (new FormatResourcesWikipediaStyleAction)->execute($resources);
+
+    expect($result)->toBe([
+        'https://techaviv.com/page1' => 'techaviv.com [1]',
+        'https://techaviv.com/page2' => '[2]',
+        'https://techaviv.com/page3' => '[3]',
+    ]);
+});
+
+it('handles multiple different domains independently', function (): void {
+    $resources = collect([
+        (object) ['url' => 'https://techaviv.com/page1'],
+        (object) ['url' => 'https://jobs.techaviv.com/job'],
+        (object) ['url' => 'https://example.com/page'],
+        (object) ['url' => 'https://example.com/other'],
+    ]);
+
+    $result = (new FormatResourcesWikipediaStyleAction)->execute($resources);
+
+    expect($result)->toBe([
+        'https://techaviv.com/page1' => 'techaviv.com [1]',
+        'https://jobs.techaviv.com/job' => 'jobs.techaviv.com [1]',
+        'https://example.com/page' => 'example.com [1]',
+        'https://example.com/other' => '[2]',
+    ]);
+});

--- a/tests/Feature/Actions/FormatResourcesActionTest.php
+++ b/tests/Feature/Actions/FormatResourcesActionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Actions\FormatResourcesAction;
+
+it('formats unique domains without suffix', function (): void {
+    $resources = collect([
+        (object) ['url' => 'https://techaviv.com/page1'],
+        (object) ['url' => 'https://jobs.techaviv.com'],
+    ]);
+
+    $result = (new FormatResourcesAction)->execute($resources);
+
+    expect($result)->toBe([
+        'https://techaviv.com/page1' => 'techaviv.com',
+        'https://jobs.techaviv.com' => 'jobs.techaviv.com',
+    ]);
+});
+
+it('adds numeric suffix for duplicate domains', function (): void {
+    $resources = collect([
+        (object) ['url' => 'https://techaviv.com/page1'],
+        (object) ['url' => 'https://techaviv.com/page2'],
+        (object) ['url' => 'https://techaviv.com/page3'],
+    ]);
+
+    $result = (new FormatResourcesAction)->execute($resources);
+
+    expect($result)->toBe([
+        'https://techaviv.com/page1' => 'techaviv.com',
+        'https://techaviv.com/page2' => 'techaviv.com [2]',
+        'https://techaviv.com/page3' => 'techaviv.com [3]',
+    ]);
+});
+
+it('handles www domains by stripping prefix', function (): void {
+    $resources = collect([
+        (object) ['url' => 'https://www.example.com/page'],
+    ]);
+
+    $result = (new FormatResourcesAction)->execute($resources);
+
+    expect($result)->toBe([
+        'https://www.example.com/page' => 'example.com',
+    ]);
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Wikipedia-style numbered References lists on Company, Investor, and Person pages, showing host-based labels, full URLs, external-link icons, and an explanatory note.

* UI/Style
  * Replaced the previous grid of resource cards with compact vertical lists for clearer, scannable references.
  * Improved handling and display of long URLs and host names.
  * Alternatives page now shows both the original references grid and an additional numbered References list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->