### PR TITLE
fix prettier write action 4

### DIFF
--- a/.github/workflows/prettier-write.yml
+++ b/.github/workflows/prettier-write.yml
@@ -1,8 +1,5 @@
 name: Format
 on:
-    push:
-        branches:
-            - main
     pull_request:
     workflow_dispatch:
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the `push` event trigger for branches from the Prettier write GitHub Actions workflow configuration.

### Why are these changes being made?

This change is made to focus the workflow on pull requests and manual dispatches, thereby reducing unnecessary runs on the `main` branch pushes. This streamlines the use of Prettier as a formatting tool primarily during pull request reviews and as needed via manual triggers.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the code-formatting workflow to run only on pull requests and manual runs, no longer on direct pushes to the main branch. This reduces unexpected automated formatting commits on main and streamlines the review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->