### PR TITLE
feat(ui): add website link icon to alternatives page

### DIFF
--- a/resources/views/alternatives/show.blade.php
+++ b/resources/views/alternatives/show.blade.php
@@ -24,7 +24,33 @@
                     </div>
 
                     <div class="flex-1">
-                        <h1 class="text-3xl font-bold text-gray-900">{{ $alternative->name }}</h1>
+                        <div class="flex items-center gap-3">
+                            <h1 class="text-3xl font-bold text-gray-900">{{ $alternative->name }}</h1>
+                            @if ($alternative->url)
+                                <a
+                                    href="{{ Str::start($alternative->url, 'https://') }}"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    title="Visit website"
+                                    class="text-blue-500 hover:text-blue-700"
+                                >
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        class="h-7 w-7"
+                                        fill="none"
+                                        viewBox="0 0 24 24"
+                                        stroke="currentColor"
+                                        stroke-width="2"
+                                    >
+                                        <path
+                                            stroke-linecap="round"
+                                            stroke-linejoin="round"
+                                            d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                                        />
+                                    </svg>
+                                </a>
+                            @endif
+                        </div>
                         <p class="mt-3 text-lg text-gray-600">{{ $alternative->description }}</p>
 
                         <!-- Tags -->
@@ -86,16 +112,6 @@
                                             <p class="mb-4 flex-1 text-gray-600">
                                                 {{ Str::limit($company->description, 120) }}
                                             </p>
-                                            @if ($company->url && $company->url !== '#')
-                                                <a
-                                                    href="{{ $company->url }}"
-                                                    target="_blank"
-                                                    class="inline-block truncate text-blue-600 hover:text-blue-800 hover:underline"
-                                                    title="{{ $company->url }}"
-                                                >
-                                                    {{ parse_url($company->url, PHP_URL_HOST) }}
-                                                </a>
-                                            @endif
                                         </div>
                                     </div>
                                 @endforeach


### PR DESCRIPTION
- Added external link icon next to alternative name for quick website access
- Simplified company cards by removing individual URL displays
- Improved visual hierarchy and user experience

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a website link icon next to the alternative name on the alternatives page, and remove individual company website links.

### Why are these changes being made?

The addition of the website link icon provides a more intuitive and visually cohesive way for users to access alternative websites directly from the main alternative heading. The removal of individual company website links simplifies the UI and focuses on the main alternative entity. This streamlining improves user experience and UI consistency.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an external-link icon next to each alternative’s name that opens the site in a new tab with appropriate security attributes and tooltip.
* **Style**
  * Streamlined the header by removing the company URL host link, keeping the focus on the alternative and its description.
  * Aligned the alternative name and link icon on a single line for a cleaner, more readable layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->