### PR TITLE
feat: add company redirect route for backward compatibility

### DIFF
--- a/app/Http/Controllers/CompanyController.php
+++ b/app/Http/Controllers/CompanyController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\NewCompanyRequest;
 use App\Models\Company;
 use App\Models\User;
 use App\Notification\ReviewAlternative;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
@@ -128,5 +129,10 @@ class CompanyController extends Controller
         Notification::send($admin, new ReviewAlternative($alternative, $company));
 
         return redirect()->back()->with('success', 'Thank you for suggesting an alternative');
+    }
+
+    public function redirect(Company $company): RedirectResponse
+    {
+        return redirect()->route('companies.show', $company, 301);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,8 @@ Route::get('companies/create', [CompanyController::class, 'create'])->name('comp
 Route::post('companies/store', [CompanyController::class, 'store'])->name('companies.store');
 
 Route::get('companies/{company:slug}', [CompanyController::class, 'show'])->name('companies.show');
+Route::get('company/{company:slug}', [CompanyController::class, 'redirect'])->name('company.redirect');
+
 Route::get('companies/url/{companyUrl}', [CompanyController::class, 'redirectToSlug'])->name('companies.show.url');
 Route::post(
     'companies/{company:slug}/alternatives', [CompanyController::class, 'storeAlternative']


### PR DESCRIPTION
- Add redirect route from /company/{slug} to /companies/{slug} to maintain URL compatibility and prevent broken links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for /company/{slug} URLs that automatically 301-redirect to the existing company detail page.
  - Ensures legacy or external singular-URL links seamlessly reach the correct company profile.
  - Maintains slug-based URL consistency for company pages.
  - No changes required for existing /companies/{slug} links; they continue to function as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->