### PR TITLE
feat: improve overall contact message UX with spam protection

### DIFF
--- a/app/Filament/Resources/ContactMessageResource.php
+++ b/app/Filament/Resources/ContactMessageResource.php
@@ -5,16 +5,26 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\ContactMessageResource\Pages\ListContactMessages;
 use App\Filament\Resources\ContactMessageResource\Pages\ViewContactMessage;
 use App\Models\ContactMessage;
+use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
+use Filament\Support\Enums\FontWeight;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\ActionGroup;
 use Filament\Tables\Actions\BulkActionGroup;
 use Filament\Tables\Actions\DeleteBulkAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 class ContactMessageResource extends Resource
 {
@@ -28,9 +38,22 @@ class ContactMessageResource extends Resource
     {
         return $form
             ->schema([
-                TextInput::make('name'),
-                TextInput::make('email')->email(),
-                Textarea::make('message')->columnSpanFull(),
+                Section::make('Message')
+                    ->schema([
+                        TextInput::make('name'),
+                        TextInput::make('email')->email(),
+                        Textarea::make('message')->rows(8)->columnSpanFull(),
+                    ]),
+
+                Section::make('Message Info')
+                    ->schema([
+                        Placeholder::make('created_at')
+                            ->label('Received at')
+                            ->content(fn (?Model $record) => $record?->created_at?->format('F j, Y \a\t g:i A')),
+                        Placeholder::make('read_at')
+                            ->label('Read at')
+                            ->content(fn (?Model $record) => $record?->read_at ? $record->read_at->format('F j, Y \a\t g:i A') : 'Not read yet'),
+                    ])->columns(3),
             ]);
     }
 
@@ -38,22 +61,130 @@ class ContactMessageResource extends Resource
     {
         return $table
             ->columns([
-                TextColumn::make('name')->searchable()->sortable(),
-                TextColumn::make('email')->searchable()->sortable(),
-                IconColumn::make('is_read')->boolean()->sortable(),
+                TextColumn::make('name')->searchable()->limit(20)->sortable(),
+                TextColumn::make('email')->searchable()->copyable()->weight(FontWeight::Bold)->copyMessage('Email copied!')->sortable(),
+                TextColumn::make('message')
+                    ->limit(30)
+                    ->tooltip(function (TextColumn $column): ?string {
+                        $state = $column->getState();
+
+                        if (strlen($state) <= 30) {
+                            return null;
+                        }
+
+                        return Str::limit($state, 250);
+                    }),
+                IconColumn::make('is_read')
+                    ->label('Is Opened')
+                    ->boolean()
+                    ->tooltip(fn ($state): string => $state ? 'Message has been opened' : 'Message not opened yet')
+                    ->sortable(),
+                IconColumn::make('is_spam')
+                    ->label('Spam Status')
+                    ->boolean()
+                    ->trueIcon('heroicon-o-shield-exclamation')
+                    ->falseIcon('heroicon-o-check-circle')
+                    ->trueColor('danger')
+                    ->falseColor('success')
+                    ->tooltip(fn ($state): string => $state ? 'Marked as spam - email and IP blocked' : 'Not spam - legitimate message')
+                    ->sortable(),
                 TextColumn::make('created_at')->dateTime()->sortable(),
             ])
             ->filters([
-                //
+                TernaryFilter::make('is_read')
+                    ->label('Read Status')
+                    ->placeholder('All messages')
+                    ->trueLabel('Opened messages')
+                    ->falseLabel('Not opened messages')
+                    ->queries(
+                        true: fn (Builder $query) => $query->whereNotNull('read_at'),
+                        false: fn (Builder $query) => $query->whereNull('read_at'),
+                    ),
+
+                TernaryFilter::make('spam_at')
+                    ->label('Spam Status')
+                    ->placeholder('All messages')
+                    ->trueLabel('Spam messages')
+                    ->falseLabel('Not spam messages')
+                    ->queries(
+                        true: fn (Builder $query) => $query->whereNotNull('spam_at'),
+                        false: fn (Builder $query) => $query->whereNull('spam_at'),
+                    ),
+
+                SelectFilter::make('created_at')
+                    ->label('Received')
+                    ->options([
+                        'today' => 'Today',
+                        'yesterday' => 'Yesterday',
+                        'this_week' => 'This week',
+                        'this_month' => 'This month',
+                        'last_month' => 'Last month',
+                    ])
+                    ->query(function (Builder $query, array $data) {
+                        if (! $data['value']) {
+                            return $query;
+                        }
+
+                        return match ($data['value']) {
+                            'today' => $query->whereDate('created_at', today()),
+                            'yesterday' => $query->whereDate('created_at', today()->subDay()),
+                            'this_week' => $query->whereBetween('created_at', [now()->startOfWeek(), now()->endOfWeek()]),
+                            'this_month' => $query->whereMonth('created_at', now()->month)->whereYear('created_at', now()->year),
+                            'this_year' => $query->whereMonth('created_at', now()->subYear()->year),
+                            default => $query,
+                        };
+                    }),
             ])
             ->actions([
-                ViewAction::make(),
+                ActionGroup::make([
+                    ViewAction::make(),
+
+                    Action::make('mark_as_read')
+                        ->label('Mark as Opened')
+                        ->icon('heroicon-m-check')
+                        ->color('success')
+                        ->visible(fn (Model $record): bool => ! $record->read_at)
+                        ->action(fn (Model $record) => $record->update(['read_at' => now()]))
+                        ->after(fn () => redirect()->back()),
+
+                    Action::make('mark_as_unread')
+                        ->label('Mark as Unopened')
+                        ->icon('heroicon-m-x-mark')
+                        ->color('warning')
+                        ->visible(fn (Model $record) => $record->read_at)
+                        ->action(fn (Model $record) => $record->update(['read_at' => null]))
+                        ->after(fn () => redirect()->back()),
+
+                    Action::make('mark_as_spam')
+                        ->label('Mark as Spam')
+                        ->icon('heroicon-m-shield-exclamation')
+                        ->color('danger')
+                        ->visible(fn (Model $record): bool => ! $record->spam_at)
+                        ->requiresConfirmation()
+                        ->modalHeading('Mark as Spam')
+                        ->modalDescription('This will mark the message as spam and prevent future messages from this email address and IP address.')
+                        ->action(fn (Model $record) => $record->markAsSpam())
+                        ->after(fn () => redirect()->back()),
+
+                    Action::make('mark_as_not_spam')
+                        ->label('Mark as Not Spam')
+                        ->icon('heroicon-m-check-circle')
+                        ->color('success')
+                        ->visible(fn (Model $record) => $record->spam_at)
+                        ->requiresConfirmation()
+                        ->modalHeading('Mark as Not Spam')
+                        ->modalDescription('This will unmark the message as spam and allow future messages from this email address and IP address.')
+                        ->action(fn (Model $record) => $record->markAsNotSpam())
+                        ->after(fn () => redirect()->back()),
+                ]),
             ])
             ->bulkActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),
                 ]),
-            ]);
+            ])
+
+            ->defaultSort('created_at', 'desc');
     }
 
     public static function getRelations(): array
@@ -70,7 +201,9 @@ class ContactMessageResource extends Resource
 
     public static function getNavigationBadge(): ?string
     {
-        return static::getModel()::notRead()->count();
+        $count = static::getModel()::whereNull('read_at')->count();
+
+        return $count > 0 ? (string) $count : null;
     }
 
     public static function getPages(): array

--- a/app/Models/ContactMessage.php
+++ b/app/Models/ContactMessage.php
@@ -4,11 +4,13 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use OwenIt\Auditing\Contracts\Auditable;
 
 class ContactMessage extends Model implements Auditable
 {
+    use HasFactory;
     use \OwenIt\Auditing\Auditable;
 
     protected $fillable = [
@@ -16,14 +18,23 @@ class ContactMessage extends Model implements Auditable
         'email',
         'message',
         'read_at',
+        'spam_at',
+        'ip_address',
     ];
 
     protected function casts(): array
     {
         return [
             'read_at' => 'datetime',
+            'spam_at' => 'datetime',
         ];
     }
+
+    /**
+     * =====================
+     *  Attributes
+     * =====================
+     */
 
     /**
      * get boolean value for is_read to make Filament IconColumn boolean
@@ -38,6 +49,40 @@ class ContactMessage extends Model implements Auditable
         );
     }
 
+    protected function isSpam(): Attribute
+    {
+        return Attribute::make(
+            get: function (): bool {
+                return $this->spam_at !== null;
+            }
+        );
+    }
+
+    /**
+     * =====================
+     *  Scopes
+     * =====================
+     */
+    public function scopeNotRead(Builder $query): Builder
+    {
+        return $query->whereNull('read_at');
+    }
+
+    public function scopeSpam(Builder $query): Builder
+    {
+        return $query->whereNotNull('spam_at');
+    }
+
+    public function scopeNotSpam(Builder $query): Builder
+    {
+        return $query->whereNull('spam_at');
+    }
+
+    /**
+     * =====================
+     * Methods
+     * =====================
+     */
     public function markAsRead(): void
     {
         $this->update([
@@ -45,8 +90,17 @@ class ContactMessage extends Model implements Auditable
         ]);
     }
 
-    public function scopeNotRead(Builder $query): Builder
+    public function markAsSpam(): void
     {
-        return $query->whereNull('read_at');
+        $this->update([
+            'spam_at' => now(),
+        ]);
+    }
+
+    public function markAsNotSpam(): void
+    {
+        $this->update([
+            'spam_at' => null,
+        ]);
     }
 }

--- a/database/factories/ContactMessageFactory.php
+++ b/database/factories/ContactMessageFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ContactMessage;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ContactMessage>
+ */
+class ContactMessageFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'email' => fake()->safeEmail(),
+            'message' => fake()->paragraph(3),
+            'ip_address' => fake()->ipv4(),
+            'read_at' => null,
+            'spam_at' => null,
+        ];
+    }
+
+    /**
+     * Mark the contact message as read.
+     */
+    public function read(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'read_at' => now(),
+        ]);
+    }
+
+    /**
+     * Mark the contact message as spam.
+     */
+    public function spam(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'spam_at' => now(),
+        ]);
+    }
+}

--- a/database/migrations/2025_09_06_143506_add_spam_column_to_contact_messages_table.php
+++ b/database/migrations/2025_09_06_143506_add_spam_column_to_contact_messages_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('contact_messages', function (Blueprint $table): void {
+            $table->timestamp('spam_at')->nullable()->after('read_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('contact_messages', function (Blueprint $table): void {
+            $table->dropColumn('spam_at');
+        });
+    }
+};

--- a/database/migrations/2025_09_06_145902_add_ip_address_to_contact_messages_table.php
+++ b/database/migrations/2025_09_06_145902_add_ip_address_to_contact_messages_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('contact_messages', function (Blueprint $table): void {
+            $table->string('ip_address', 45)->nullable()->after('spam_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('contact_messages', function (Blueprint $table): void {
+            $table->dropColumn('ip_address');
+        });
+    }
+};

--- a/tests/Feature/ContactFormTest.php
+++ b/tests/Feature/ContactFormTest.php
@@ -1,0 +1,213 @@
+<?php
+
+use App\Models\ContactMessage;
+
+describe('Contact Form Validation', function (): void {
+    it('requires name field', function (): void {
+        $response = $this->post(route('contact.store'), [
+            'email' => 'test@example.com',
+            'message' => 'This is a test message that is long enough.',
+        ]);
+
+        $response->assertSessionHasErrors('name');
+    });
+
+    it('requires email field', function (): void {
+        $response = $this->post(route('contact.store'), [
+            'name' => 'Test User',
+            'message' => 'This is a test message that is long enough.',
+        ]);
+
+        $response->assertSessionHasErrors('email');
+    });
+
+    it('requires valid email format', function (): void {
+        $response = $this->post(route('contact.store'), [
+            'name' => 'Test User',
+            'email' => 'invalid-email',
+            'message' => 'This is a test message that is long enough.',
+        ]);
+
+        $response->assertSessionHasErrors('email');
+    });
+
+    it('requires message field', function (): void {
+        $response = $this->post(route('contact.store'), [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+        ]);
+
+        $response->assertSessionHasErrors('message');
+    });
+
+    it('requires message to be at least 10 characters', function (): void {
+        $response = $this->post(route('contact.store'), [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'message' => 'Short',
+        ]);
+
+        $response->assertSessionHasErrors('message');
+    });
+
+    it('limits message to 10000 characters', function (): void {
+        $longMessage = str_repeat('a', 10001);
+
+        $response = $this->post(route('contact.store'), [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'message' => $longMessage,
+        ]);
+
+        $response->assertSessionHasErrors('message');
+    });
+
+    it('limits name to 255 characters', function (): void {
+        $longName = str_repeat('a', 256);
+
+        $response = $this->post(route('contact.store'), [
+            'name' => $longName,
+            'email' => 'test@example.com',
+            'message' => 'This is a test message that is long enough.',
+        ]);
+
+        $response->assertSessionHasErrors('name');
+    });
+});
+
+describe('Contact Form Submission', function (): void {
+    it('successfully creates contact message with valid data', function (): void {
+        $data = [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'message' => 'This is a test message that is long enough to pass validation.',
+        ];
+
+        $response = $this->post(route('contact.store'), $data);
+
+        $response->assertRedirect()
+            ->assertSessionHas('success', 'Message sent successfully');
+
+        $this->assertDatabaseHas('contact_messages', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'message' => 'This is a test message that is long enough to pass validation.',
+            'ip_address' => '127.0.0.1',
+        ]);
+    });
+
+    it('captures IP address when creating contact message', function (): void {
+        $data = [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'message' => 'This is a test message that is long enough to pass validation.',
+        ];
+
+        $response = $this->from('http://example.com')
+            ->withServerVariables(['REMOTE_ADDR' => '192.168.1.100'])
+            ->post(route('contact.store'), $data);
+
+        $response->assertRedirect()
+            ->assertSessionHas('success', 'Message sent successfully');
+
+        $this->assertDatabaseHas('contact_messages', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'ip_address' => '192.168.1.100',
+        ]);
+    });
+});
+
+describe('Spam Protection', function (): void {
+    it('blocks submission from spam email address', function (): void {
+        // First, create a spam message
+        ContactMessage::factory()->create([
+            'email' => 'spam@example.com',
+            'spam_at' => now(),
+        ]);
+
+        $data = [
+            'name' => 'Test User',
+            'email' => 'spam@example.com',
+            'message' => 'This should be blocked because email is marked as spam.',
+        ];
+
+        $response = $this->post(route('contact.store'), $data);
+
+        $response->assertRedirect()
+            ->assertSessionHas('error', 'Unable to send message. Please try again later.');
+
+        // Verify no new message was created
+        $this->assertEquals(1, ContactMessage::query()->where('email', 'spam@example.com')->count());
+    });
+
+    it('blocks submission from spam IP address', function (): void {
+        // First, create a spam message with IP
+        ContactMessage::factory()->create([
+            'ip_address' => '192.168.1.100',
+            'spam_at' => now(),
+        ]);
+
+        $data = [
+            'name' => 'Test User',
+            'email' => 'different@example.com',
+            'message' => 'This should be blocked because IP is marked as spam.',
+        ];
+
+        $response = $this->withServerVariables(['REMOTE_ADDR' => '192.168.1.100'])
+            ->post(route('contact.store'), $data);
+
+        $response->assertRedirect()
+            ->assertSessionHas('error', 'Unable to send message. Please try again later.');
+
+        // Verify no new message was created for this email
+        $this->assertEquals(0, ContactMessage::query()->where('email', 'different@example.com')->count());
+    });
+
+    it('allows submission from non-spam email and IP', function (): void {
+        // Create a spam message with different email and IP
+        ContactMessage::factory()->create([
+            'email' => 'spam@example.com',
+            'ip_address' => '192.168.1.100',
+            'spam_at' => now(),
+        ]);
+
+        $data = [
+            'name' => 'Test User',
+            'email' => 'legitimate@example.com',
+            'message' => 'This should be allowed because email and IP are not spam.',
+        ];
+
+        $response = $this->withServerVariables(['REMOTE_ADDR' => '192.168.1.200'])
+            ->post(route('contact.store'), $data);
+
+        $response->assertRedirect()
+            ->assertSessionHas('success', 'Message sent successfully');
+
+        $this->assertDatabaseHas('contact_messages', [
+            'email' => 'legitimate@example.com',
+            'ip_address' => '192.168.1.200',
+        ]);
+    });
+
+    it('allows submission from unmarked spam email', function (): void {
+        // Create a message that was spam but is no longer marked as spam
+        ContactMessage::factory()->create([
+            'email' => 'reformed@example.com',
+            'spam_at' => null, // Not spam anymore
+        ]);
+
+        $data = [
+            'name' => 'Test User',
+            'email' => 'reformed@example.com',
+            'message' => 'This should be allowed because email is no longer marked as spam.',
+        ];
+
+        $response = $this->post(route('contact.store'), $data);
+
+        $response->assertRedirect()
+            ->assertSessionHas('success', 'Message sent successfully');
+
+        $this->assertEquals(2, ContactMessage::query()->where('email', 'reformed@example.com')->count());
+    });
+});


### PR DESCRIPTION
  - Add spam_at column to contact_messages table for spam tracking
  - Add ip_address column to capture sender IP addresses
  - Implement markAsSpam() and markAsNotSpam() methods in ContactMessage model
  - Add spam blocking logic to contact form preventing submissions from blocked emails/IPs
  - Add "Mark as Spam" and "Mark as Not Spam" actions in Filament admin interface
  - Add spam status filters and enhanced UI with custom icons and tooltips
  - Create comprehensive test suite covering validation, submission, and spam protection
  - Add ContactMessageFactory with spam/read states for testing