### PR TITLE
fix: use absolute sitemap for robots.txt to satisfy some sitemap craw…

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Disallow: /admin/
 
-Sitemap: /sitemap.xml
+Sitemap: https://israelitechalternatives.com/sitemap.xml


### PR DESCRIPTION
…lers like yandex instead or relative path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated robots.txt to use an absolute Sitemap URL instead of a relative path. This improves reliability of sitemap discovery by search engines and external tools, especially across mirrors, previews, or non-root contexts. Crawling directives remain unchanged; no impact on site functionality for visitors. Helps ensure faster indexing and reduces misconfiguration risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->