### PR TITLE
fix: add new company by users

### DIFF
--- a/app/Http/Controllers/CompanyController.php
+++ b/app/Http/Controllers/CompanyController.php
@@ -55,7 +55,6 @@ class CompanyController extends Controller
             'name' => $data['name'],
             'url' => $data['url'],
             'description' => $data['description'],
-            'notes' => $data['notes'],
         ]);
 
         return to_route('alternatives.index')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Company creation now saves only name, URL, and description. Any notes entered during creation will not be stored or displayed.
  * Prevents unintended capture of auxiliary notes during the add-company flow.
  * Ensures consistent behavior across UI and integrations by ignoring unsupported fields during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->