### PR TITLE
fix: opcache route when user not logged on

### DIFF
--- a/app/Http/Controllers/OpCacheController.php
+++ b/app/Http/Controllers/OpCacheController.php
@@ -11,7 +11,7 @@ class OpCacheController extends Controller
      */
     public function __invoke(): Response
     {
-        abort_if(! auth()->check() || ! auth()->user()->hasRole('super_admin'), 403, 'Unauthorized');
+        abort_if(! auth()->check() || ! auth()->user()->hasRole('super_admin'), 404);
 
         // Path to the opcache-gui index.php
         $indexPath = base_path('vendor/amnuts/opcache-gui/index.php');

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,4 +48,4 @@ Route::get('similar-sites', [HomeController::class, 'similarSites'])->name('simi
 Route::get('webhooks/mailchimp', MailchimpRedirectionController::class)->name('mailchimp.webhook');
 
 // OpCache GUI (Super Admin Only)
-Route::get('opcache', OpCacheController::class)->middleware('auth')->name('opcache');
+Route::get('opcache', OpCacheController::class)->name('opcache');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * OpCache route is now publicly accessible without authentication
  * Error response status code updated from 403 to 404 for access restrictions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->