### PR TITLE
Bugfix #188: Pick logos from the backend

### DIFF
--- a/app/Console/Commands/AttachCompaniesImagesCommand.php
+++ b/app/Console/Commands/AttachCompaniesImagesCommand.php
@@ -75,6 +75,8 @@ class AttachCompaniesImagesCommand extends Command
                         }
                     }
                 } else {
+                    $notes['notes'] = 'image attached';
+                    $company->update(['notes' => $notes]);
                     $this->info("Successfully add image from folder for company:$company->name");
                     $succeeded++;
                 }

--- a/app/Console/Commands/AttachCompaniesImagesCommand.php
+++ b/app/Console/Commands/AttachCompaniesImagesCommand.php
@@ -53,38 +53,37 @@ class AttachCompaniesImagesCommand extends Command
                 return;
             }
 
-            if ($notes['url']) {
-                $imagePath = get_image_archive_path($notes['url'], 'companies');
-                DB::beginTransaction();
-                try {
-                    if (! add_image_for_model($imagePath, $company)) {
-                        $this->info("Failed to add image from folder for company:$company->name");
+            $imagePath = get_image_archive_path($notes['url'], 'companies');
+            DB::beginTransaction();
+            try {
+                if (! add_image_for_model($imagePath, $company)) {
+                    $this->info("Failed to add image from folder for company:$company->name");
 
-                        if (Str::isUrl($notes['url'])) {
-                            $this->info('Try to Download it from Url..');
+                    if (Str::isUrl($notes['url'])) {
+                        $this->info('Try to Download it from Url..');
 
-                            try {
-                                $company->addMediaFromUrl($notes['url'])->toMediaCollection();
-                                $this->info("Successfully add image from Url for company:$company->name");
-                                $notes['notes'] = 'image attached';
-                                $company->update(['notes' => $notes]);
-                                $succeeded++;
-                            } catch (Exception $e) {
-                                $this->info("Failed to add image from url for company:$company->name");
-                                $this->error($e->getMessage());
-                                $failed++;
-                            }
+                        try {
+                            $company->addMediaFromUrl($notes['url'])->toMediaCollection();
+                            $this->info("Successfully add image from Url for company:$company->name");
+                            $notes['notes'] = 'image attached';
+                            $company->update(['notes' => $notes]);
+                            $succeeded++;
+                        } catch (Exception $e) {
+                            $this->info("Failed to add image from url for company:$company->name");
+                            $this->error($e->getMessage());
+                            $failed++;
                         }
-                    } else {
-                        $this->info("Successfully add image from folder for company:$company->name");
-                        $succeeded++;
                     }
-                    DB::commit();
-                } catch (Exception $e) {
-                    DB::rollback();
-                    $this->error($e->getMessage());
+                } else {
+                    $this->info("Successfully add image from folder for company:$company->name");
+                    $succeeded++;
                 }
+                DB::commit();
+            } catch (Exception $e) {
+                DB::rollback();
+                $this->error($e->getMessage());
             }
+
         });
         // });
 

--- a/app/Console/Commands/AttachCompaniesImagesCommand.php
+++ b/app/Console/Commands/AttachCompaniesImagesCommand.php
@@ -16,7 +16,7 @@ class AttachCompaniesImagesCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'attach-images-companies';
+    protected $signature = 'import:attach-images-companies';
 
     /**
      * The console command description.
@@ -45,43 +45,45 @@ class AttachCompaniesImagesCommand extends Command
             /** @var Collection $notes * */
             $notes = $company->notes;
 
-            if ($notes->first() == 'image attached') {
+            if (isset($notes['notes']) && $notes['notes'] == 'image attached') {
                 return;
             }
 
-            $url = $notes->groupBy('url')->keys()->first();
+            if (! isset($notes['url'])) {
+                return;
+            }
 
-            $imagePath = get_image_archive_path($url, 'companies');
+            if ($notes['url']) {
+                $imagePath = get_image_archive_path($notes['url'], 'companies');
+                DB::beginTransaction();
+                try {
+                    if (! add_image_for_model($imagePath, $company)) {
+                        $this->info("Failed to add image from folder for company:$company->name");
 
-            DB::beginTransaction();
+                        if (Str::isUrl($notes['url'])) {
+                            $this->info('Try to Download it from Url..');
 
-            try {
-                if (! add_image_for_model($imagePath, $company)) {
-                    $this->info("Failed to add image from folder for company:$company->name");
-
-                    if (Str::isUrl($url)) {
-                        $this->info('Try to Download it from Url..');
-
-                        try {
-                            $company->addMediaFromUrl($url)->toMediaCollection();
-                            $this->info("Successfully add image from Url for person:$company->name");
-                            $succeeded++;
-                        } catch (Exception) {
-                            $this->info("Failed to add image from url for person:$company->name");
-                            $failed++;
+                            try {
+                                $company->addMediaFromUrl($notes['url'])->toMediaCollection();
+                                $this->info("Successfully add image from Url for company:$company->name");
+                                $notes['notes'] = 'image attached';
+                                $company->update(['notes' => $notes]);
+                                $succeeded++;
+                            } catch (Exception $e) {
+                                $this->info("Failed to add image from url for company:$company->name");
+                                $this->error($e->getMessage());
+                                $failed++;
+                            }
                         }
+                    } else {
+                        $this->info("Successfully add image from folder for company:$company->name");
+                        $succeeded++;
                     }
-                } else {
-                    $this->info("Successfully add image from folder for company:$company->name");
-                    $succeeded++;
+                    DB::commit();
+                } catch (Exception $e) {
+                    DB::rollback();
+                    $this->error($e->getMessage());
                 }
-
-                $company->update(['notes' => 'image attached']);
-
-                DB::commit();
-            } catch (Exception $e) {
-                DB::rollback();
-                $this->error($e->getMessage());
             }
         });
         // });

--- a/app/Console/Commands/AttachPeopleImagesCommand.php
+++ b/app/Console/Commands/AttachPeopleImagesCommand.php
@@ -78,6 +78,8 @@ class AttachPeopleImagesCommand extends Command
                         }
                     }
                 } else {
+                    $notes['notes'] = 'image attached';
+                    $person->update(['notes' => $notes]);
                     $this->info("Successfully add image from folder for person:$person->name");
                     $succeeded++;
                 }

--- a/app/Console/Commands/AttachPeopleImagesCommand.php
+++ b/app/Console/Commands/AttachPeopleImagesCommand.php
@@ -16,7 +16,7 @@ class AttachPeopleImagesCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'attach-images-people';
+    protected $signature = 'import:attach-images-people';
 
     /**
      * The console command description.
@@ -48,28 +48,32 @@ class AttachPeopleImagesCommand extends Command
             /** @var Collection $notes * */
             $notes = $person->notes;
 
-            if ($notes->first() == 'image attached') {
+            if (isset($notes['notes']) && $notes['notes'] == 'image attached') {
                 return;
             }
 
-            $url = $notes->groupBy('url')->keys()->first();
+            if (! isset($notes['url'])) {
+                return;
+            }
 
-            $imagePath = get_image_archive_path($url, 'people');
-
+            $imagePath = get_image_archive_path($notes['url'], 'people');
             DB::beginTransaction();
-
             try {
                 if (! add_image_for_model($imagePath, $person)) {
                     $this->info("Failed to add image from folder for person:$person->name");
 
-                    if (Str::isUrl($url)) {
+                    if (Str::isUrl($notes['url'])) {
                         $this->info('Try to Download it from Url..');
 
                         try {
-                            $person->addMediaFromUrl($url)->toMediaCollection();
+                            $person->addMediaFromUrl($notes['url'])->toMediaCollection();
                             $this->info("Successfully add image from Url for person:$person->name");
-                        } catch (Exception) {
+                            $notes['notes'] = 'image attached';
+                            $person->update(['notes' => $notes]);
+                            $succeeded++;
+                        } catch (Exception $e) {
                             $this->info("Failed to add image from url for person:$person->name");
+                            $this->error($e->getMessage());
                             $failed++;
                         }
                     }
@@ -77,9 +81,6 @@ class AttachPeopleImagesCommand extends Command
                     $this->info("Successfully add image from folder for person:$person->name");
                     $succeeded++;
                 }
-
-                $person->update(['notes' => 'image attached']);
-
                 DB::commit();
             } catch (Exception $e) {
                 DB::rollback();

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -86,6 +86,7 @@ class Company extends Model implements Auditable, HasMedia
             'approved_at' => 'timestamp',
             'last_funding_date' => 'date',
             'founded_at' => 'date',
+            'notes' => 'array',
         ];
     }
 

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -51,7 +51,7 @@ class Person extends Model implements Auditable, HasMedia
             'id' => 'integer',
             'approved_at' => 'timestamp',
             'social_links' => 'array',
-            'notes' => 'collection',
+            'notes' => 'array',
         ];
     }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -75,7 +75,7 @@ if (! function_exists('add_image_urls_to_notes')) {
             return false;
         }
 
-        $oldNotes = collect(json_decode($model->notes, true));
+        // $oldNotes = collect(json_decode($model->notes, true));
 
         $newNote = [
             'url' => $url,
@@ -83,12 +83,13 @@ if (! function_exists('add_image_urls_to_notes')) {
             'class' => class_basename($class),
         ];
 
-        // Append the new note (if old notes exist, merge them)
-        $appendedNotes = $oldNotes->isEmpty()
-            ? collect([$newNote])  // If old notes are empty, just create a new collection with the new note
-            : $oldNotes->push($newNote);  // Otherwise, push the new note to the collection
+        // This line creates nested arrays and causes issues with logo import scripts
+        // // Append the new note (if old notes exist, merge them)
+        // $appendedNotes = $oldNotes->isEmpty()
+        //     ? collect([$newNote])  // If old notes are empty, just create a new collection with the new note
+        //     : $oldNotes->push($newNote);  // Otherwise, push the new note to the collection
 
-        return $model->update(['notes' => $appendedNotes->toJson()]);
+        return $model->update(['notes' => $newNote]);
     }
 }
 


### PR DESCRIPTION
- Updated add_image_urls_to_notes function to prevent creating nested arrays. 
- Cast notes field in Person and Company models as array to also prevent type errors and fetch/update data correctly.
- Updated AttachCompaniesImagesCommand and AttachPeopleImagesCommand to correcly pull image url from notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized image-attachment commands under a unified import namespace.
  * Simplified note storage to use plain arrays and write single-note updates.
  * Improved logging, progress tracking and success/failure reporting for image imports.

* **Bug Fixes**
  * More robust URL handling and defensive checks to reduce failed downloads and duplicate attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->